### PR TITLE
Fix duplicate discord.gg/ prefix

### DIFF
--- a/src/bot/events/guildMemberAdd.js
+++ b/src/bot/events/guildMemberAdd.js
@@ -36,7 +36,7 @@ To see the rest of the channels within our server, please click the button below
 
 Have fun in ${member.guild.name} We're excited to have you join our wonderful community!
 
-Permanent invite link: https://discord.gg/${config.guilds[member.guild.id].invite}`,
+Permanent invite link: ${config.guilds[member.guild.id].invite}`,
 
             components: [
                 new ActionRowBuilder()


### PR DESCRIPTION
The template string includes `discord.gg/...` but the config variables also include that, so the invites end up broken. The links actually do still work, but it won't embed and will look wrong to the end user.