### PR TITLE
feat: Add TransDice! config

### DIFF
--- a/src/config/config.d.ts
+++ b/src/config/config.d.ts
@@ -1,0 +1,98 @@
+import type { ChannelType, ThreadAutoArchiveDuration, Snowflake } from 'discord.js';
+
+export interface Guild {
+  sync: Snowflake[];
+  verifyTicketAutoArchiveDuration: ThreadAutoArchiveDuration;
+  privateThread: ChannelType;
+  channels: {
+    /// The channel that verification threads are created in
+    lobby: Snowflake;
+
+    /// A channel used to log verification starts and successes
+    verifyLogs: Snowflake;
+
+    /// A channel used to log verification kicks and bans
+    verifyLogsSecondary: Snowflake;
+
+    /// A channel where 'new member' messages will be sent
+    /// If this is not specified, no new member messages will be sent
+    /// If this is specified, the greeter role and call-to-action channels must also be specified
+    welcome: Snowflake?;
+
+    /// A channel for the new-member "here's a place to talk" call to action
+    /// Required if and only if the welcome channel is specified
+    general: Snowflake?;
+
+    /// A channel for the new member "introduce yourself" call to action
+    /// Required if and only if the welcome channel is specified
+    introduce: Snowflake?;
+  };
+  roles: {
+    /// Used for determining if a user can run commands
+    staffRoles: Snowflake[];
+
+    /// Used for determining if a user can verify users
+    verifier: Snowflake;
+
+    /// Given to users when they are verified
+    verified: Snowflake;
+
+    /// A role that new server members get upon verification
+    /// The bot will never *un*assign this role - you're expected to use another bot (e.g. a level bot or a bot to remove this role after a time)
+    /// If omitted, the bot will not assign a newbie role
+    newbie: Snowflake?;
+
+    /// A role that will be given with the "verify with no images" options
+    /// The bot will never *un*assign this role - you should probably give your moderators another way to manage this (e.g. through Badeline)
+    /// FIXME: If omitted, the bot will still show the non-image-verification options but they will act the same as verification
+    noImages: Snowflake?;
+
+    /// A role which indicates a member took part in r/place 2023
+    /// If a member has this role, the Kyle webhook will ask them for their Reddit account
+    /// This probably isn't useful except in TransPlace!
+    /// If omitted, the bot will never ask about r/place 2023
+    place: Snowflake?;
+
+    /// A role which all members get upon joining the server
+    /// This role may not be omitted
+    member: Snowflake;
+
+    /// A role which will be pinged upon new members joining the server
+    /// This role is required if-and-only-if the welcome channel is specified
+    greeter: Snowflake?;
+
+    inactivityPing: Snowflake?;
+    catagories /* [sic] */: {
+      isTrans: Snowflake;
+      isQuestioning: Snowflake;
+      isCis: Snowflake;
+    } | {};
+  };
+  links: {
+    /// A link to somewhere with the rules (commonly a channel or thread)
+    /// Used in the verification embed
+    rules: string;
+
+    // These are used in the rules embed - by name
+
+    rule1: string;
+    rule2: string;
+    rule3: string;
+    rule5: string;
+    rule7: string;
+    rule9: string;
+    rule12: string;
+  };
+
+  /// Used in the original DM sent to members
+  invite: string;
+}
+
+export interface Config {
+  debugOut: (...log: any) => void;
+  verboseOut: (...log: any) => void;
+  clientId: string;
+  guilds: Record<Snowflake, Guild>;
+}
+
+export const config: Config;

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -338,6 +338,40 @@ const production = {
             },
             invite: 'https://discord.gg/QhTDQsyeD6',
         },
+        '1116634030834733077': {
+            // TransDice!
+            sync: [
+                '959551566388547676', // TransPlace
+                // Sync here is *intentionally 1-way to TransPlace*, as this is a spin-off server from TransPlace and generally will not be verifying people
+            ],
+            verifyTicketAutoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
+            privateThread: ChannelType.PrivateThread,
+            channels: {
+                lobby: '1342833050731548682',               // TransDice:welcome-verify
+                verifyLogs: '1342834458570657794',          // TransDice:verify-logs
+                verifyLogsSecondary: '1342835930649595995', // TransDice:verify-kick-logs
+            },
+            roles: {
+                staffRoles: [
+                    '1116668288638914641', // Blåholder
+                    '1144502144033116201', // TransPlace Staff
+                ],
+                verifier: '1116668288638914641', // Blåholder
+                verified: '1116673143013122068', // Adventurer
+                catagories: {},
+            },
+            links: {
+                rules: 'https://canary.discord.com/channels/959551566388547676/1057132419150532678/1151892231091925163',
+                rule1: 'https://canary.discord.com/channels/959551566388547676/1151689401643053107/1151694186257600522',
+                rule2: 'https://canary.discord.com/channels/959551566388547676/1151689483977236610/1151694304037838910',
+                rule3: 'https://canary.discord.com/channels/959551566388547676/1151689644052840589/1151694373424218163',
+                rule5: 'https://canary.discord.com/channels/959551566388547676/1151689706912882758/1151694425110609941',
+                rule7: 'https://canary.discord.com/channels/959551566388547676/1151689903319564329/1151690023331172412',
+                rule9: 'https://canary.discord.com/channels/959551566388547676/1151689755537457265/1151694463127793674',
+                rule12: 'https://canary.discord.com/channels/959551566388547676/1151689825687195678/1151694529750106186',
+            },
+            invite: 'https://discord.gg/YUJM2Qg55q',
+        }
     },
 };
 

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -288,7 +288,17 @@ const production = {
                     isCis: '1168292229283061760',
                 },
             },
-            invite: 'https://discord.gg/5xFg9mXTTF',
+            links: {
+                rules: 'https://canary.discord.com/channels/1087014898199969873/1255540593451335770/1258439336462909492',
+                rule1: 'https://canary.discord.com/channels/1087014898199969873/1258432882804785172/1258433967183630500',
+                rule2: 'https://canary.discord.com/channels/1087014898199969873/1258432989994680482/1258434025014431786',
+                rule3: 'https://canary.discord.com/channels/1087014898199969873/1258433032382058496/1258434063040118855',
+                rule5: 'https://canary.discord.com/channels/1087014898199969873/1258433071158395044/1258434101300691084',
+                rule7: 'https://canary.discord.com/channels/1087014898199969873/1258433115601502239/1258434279902412843',
+                rule9: 'https://canary.discord.com/channels/1087014898199969873/1258433158035013682/1258434309749215334',
+                rule12: 'https://canary.discord.com/channels/1087014898199969873/1258433194479583242/1258434330800291930',
+            },
+            invite: 'https://discord.gg/xt8WqnGffb',
         },
         '638480381552754730': {
             // Transonance

--- a/src/verification/managers/verifyUser.js
+++ b/src/verification/managers/verifyUser.js
@@ -20,7 +20,9 @@ async function closeTicket(ticket) {
  */
 async function verify(member, type) {
     await assignRole(member, config.guilds[member.guild.id].roles.verified);
-    await assignRole(member, config.guilds[member.guild.id].roles.newbie);
+    if (config.guilds[member.guild.id].roles.newbie) {
+        await assignRole(member, config.guilds[member.guild.id].roles.newbie);
+    }
     if (type === 'noImages' && config.guilds[member.guild.id].roles.noImages) {
         await assignRole(member, config.guilds[member.guild.id].roles.noImages);
     }
@@ -57,17 +59,21 @@ async function verifyUser(ticket, verifier, resolve, reject, type) {
     await verify(applicant, type);
 
     // send welcome message and create log for successful verification
-    await Promise.all([
-        sendGreetMessage(
-            ticket.guild.channels.cache.get(config.guilds[verifier.guild.id].channels.welcome),
-            applicant,
-        ),
+    const sendMessages = [
         createVerifiedLog(
             ticket.guild.channels.cache.get(config.guilds[verifier.guild.id].channels.verifyLogs),
             verifier,
             applicant,
         ),
-    ]);
+    ];
+
+    if (config.guilds[verifier.guild.id].channels.welcome) {
+        sendMessages.push(sendGreetMessage(
+            ticket.guild.channels.cache.get(config.guilds[verifier.guild.id].channels.welcome),
+            applicant,
+        ));
+    }
+    await Promise.all(sendMessages);
 
     // success
     await resolve(`${userMention(applicant.id)} has been verified`);


### PR DESCRIPTION
TransDice is a spinoff server from TransPlace, not allowing people who are not already members of TransPlace. Therefore, it makes sense to have Theo in the server, but to strip out many of its bells and whistles

Several of the features of Theo are not needed by TransDice. An example is that the welcoming feature is extraneous. Therefore, I have gated some of the code behind checks to see if config is provided. If not, the feature won't be used. I suspect some of this is written in ways that are difficult enough to read that this might not be clear: it would be worth doing some heavier refactoring around here, but I don't have the time in this commit.

To keep track of this, I've written some typescript declarations for the config. We don't currently use typescript in any capacity, but it might be usable by a language server and it perhaps a bit more useful than the documentation comment for precision...