### PR TITLE
fix server rules links

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -236,7 +236,7 @@ const production = {
                 },
             },
             links: {
-                rules: 'https://canary.discord.com/channels/959551566388547676/1057132419150532678/1151892231091925163',
+                rules: 'https://canary.discord.com/channels/959551566388547676/1057132419150532678/1379598680251699330',
                 rule1: 'https://canary.discord.com/channels/959551566388547676/1151689401643053107/1151694186257600522',
                 rule2: 'https://canary.discord.com/channels/959551566388547676/1151689483977236610/1151694304037838910',
                 rule3: 'https://canary.discord.com/channels/959551566388547676/1151689644052840589/1151694373424218163',
@@ -355,7 +355,7 @@ const production = {
                 },
             },
             links: {
-                rules: 'https://canary.discord.com/channels/959551566388547676/1057132419150532678/1151892231091925163',
+                rules: 'https://canary.discord.com/channels/638480381552754730/1255543769835769999/1379578773745434725',
                 rule1: 'https://canary.discord.com/channels/638480381552754730/1378842074467794954/1378846359737602151',
                 rule2: 'https://canary.discord.com/channels/638480381552754730/1378844409222660126/1378845977842290858',
                 rule3: 'https://canary.discord.com/channels/638480381552754730/1378862066320015510/1378862385959272509',

--- a/src/verification/controllers/ticket.js
+++ b/src/verification/controllers/ticket.js
@@ -1,6 +1,5 @@
 import {
     BaseGuildTextChannel,
-    channelMention,
     RESTJSONErrorCodes,
     roleMention,
     ThreadChannel,
@@ -165,7 +164,7 @@ async function refreshTicket(ticket, member) {
  */
 function sendPrompt(ticket, applicant, promptCategory) {
     return ticket.send({
-        content: `${userMention(applicant.id)} If you cannot see instructions in this message, please go to **User Settings**, navigate to **Chat**, and enable **Embeds And Link Previews**. You can view the rules in ${channelMention(config.guilds[ticket.guild.id].channels.lobby)}.`,
+        content: `${userMention(applicant.id)} If you cannot see instructions in this message, please go to **User Settings**, navigate to **Chat**, and enable **Embeds And Link Previews**. You can view the rules in ${config.guilds[ticket.guild.id].links.rules}.`,
         embeds: buildPromptEmbeds(applicant, promptCategory),
         components: buildPromptComponents(ticket.client),
     });


### PR DESCRIPTION
- update TP and TSO rules links to the new message
- make the no-embeds info message point to the top of the channel (via the rules link) instead of the bottom (via the channel mention)